### PR TITLE
Use a low version number

### DIFF
--- a/src/dotnet-test-xunit/project.json
+++ b/src/dotnet-test-xunit/project.json
@@ -8,7 +8,7 @@
   "licenseUrl": "https://raw.githubusercontent.com/xunit/xunit/master/license.txt",
   "requireLicenseAcceptance": false,
   "developmentDependency": true,
-  "version": "0.0.1-dev-1",
+  "version": "0.0.1-dev-2",
   "compilationOptions": {
     "warningsAsErrors": true,
     "emitEntryPoint": true

--- a/src/dotnet-test-xunit/project.json
+++ b/src/dotnet-test-xunit/project.json
@@ -8,7 +8,7 @@
   "licenseUrl": "https://raw.githubusercontent.com/xunit/xunit/master/license.txt",
   "requireLicenseAcceptance": false,
   "developmentDependency": true,
-  "version": "99.99.99-dev",
+  "version": "0.0.1-dev-1",
   "compilationOptions": {
     "warningsAsErrors": true,
     "emitEntryPoint": true


### PR DESCRIPTION
Use a low version number so that when the official xunit package comes out, it doesn't produce "older" packages than this one.

@piotrpMSFT 
