### PR TITLE
Produce dotnet-test-xunit package with native assets

### DIFF
--- a/src/dotnet-test-xunit/project.json
+++ b/src/dotnet-test-xunit/project.json
@@ -14,6 +14,18 @@
     "emitEntryPoint": true,
     "preserveCompilationContext": true
   },
+  "configurations": {
+    "debug_x86": {
+      "compilationOptions": {
+        "platform": "anycpu32bitpreferred"
+      }
+    },
+    "release_x86": {
+      "compilationOptions": {
+        "platform": "anycpu32bitpreferred"
+      }
+    }
+  },
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [


### PR DESCRIPTION
Structure of the package produced after this change:

```
│   dotnet-test-xunit.1.0.0-rc2-160478-33.nupkg
│   dotnet-test-xunit.1.0.0-rc2-160478-33.nupkg.sha512
│   dotnet-test-xunit.nuspec
│
├───lib
│   ├───net451
│   │       dotnet-test-xunit.exe
│   │
│   ├───netcoreapp1.0
│   │       dotnet-test-xunit.dll
│   │       dotnet-test-xunit.runtimeconfig.json
│   │
│   └───netstandardapp1.5
│           dotnet-test-xunit.dll
│           dotnet-test-xunit.runtimeconfig.json
│
└───runtimes
    ├───unix-x64
    │   └───lib
    │       └───net451
    │               dotnet-test-xunit.exe
    │
    ├───win7-x64
    │   └───lib
    │       └───net451
    │               dotnet-test-xunit.exe
    │
    └───win7-x86
        └───lib
            └───net451
                    dotnet-test-xunit.exe
```
